### PR TITLE
Add DomainIntel API

### DIFF
--- a/other-apis-1297/README.md
+++ b/other-apis-1297/README.md
@@ -1309,3 +1309,4 @@
 ---
 
 <p align="center"><a href="../README.md">← Back to main API list</a></p>
+| [DomainIntel](https://domainintel.onrender.com) | Real-time domain intelligence: RDAP, DNS-over-HTTPS, Certificate Transparency and bulk lookups. Free tier. |


### PR DESCRIPTION
Add DomainIntel — a real-time domain intelligence API. RDAP, DNS-over-HTTPS, Certificate Transparency, and bulk lookups. Free tier via RapidAPI. https://domainintel.onrender.com